### PR TITLE
fix: quiz question length issue

### DIFF
--- a/community/lms/doctype/lms_quiz_result/lms_quiz_result.json
+++ b/community/lms/doctype/lms_quiz_result/lms_quiz_result.json
@@ -12,7 +12,7 @@
  "fields": [
   {
    "fieldname": "question",
-   "fieldtype": "Data",
+   "fieldtype": "Text",
    "in_list_view": 1,
    "label": "Question"
   },
@@ -33,7 +33,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-06-22 18:32:28.813159",
+ "modified": "2021-10-12 10:32:45.139121",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Quiz Result",


### PR DESCRIPTION
**Issue:**

The Quiz submission doctype was throwing an error when the length of questions exceeded 140 characters.

![image](https://user-images.githubusercontent.com/31363128/136894835-2471dc79-f09e-45ba-a624-bc3e22c2b100.png)

**Fix:**

Question field in LMS Quiz Result table was a Data field. Changed this field to Text field.