### PR TITLE
fix: get progress from membership

### DIFF
--- a/community/lms/doctype/course_lesson/course_lesson.py
+++ b/community/lms/doctype/course_lesson/course_lesson.py
@@ -65,11 +65,12 @@ class CourseLesson(Document):
 
 @frappe.whitelist()
 def save_progress(lesson, course, status):
-    if not frappe.db.exists("LMS Batch Membership",
-            {
-                "member": frappe.session.user,
-                "course": course
-            }):
+    membership = frappe.db.exists("LMS Batch Membership",
+                    {
+                        "member": frappe.session.user,
+                        "course": course
+                    })
+    if not membership:
         return
 
     if frappe.db.exists("LMS Course Progress",
@@ -92,5 +93,8 @@ def save_progress(lesson, course, status):
             "lesson": lesson,
             "status": status,
         }).save(ignore_permissions=True)
+
     course_details = frappe.get_doc("LMS Course", course)
-    return course_details.get_course_progress()
+    progress = course_details.get_course_progress()
+    frappe.db.set_value("LMS Batch Memebership", membership, "progress", progress)
+    return progress

--- a/community/lms/doctype/course_lesson/course_lesson.py
+++ b/community/lms/doctype/course_lesson/course_lesson.py
@@ -96,5 +96,5 @@ def save_progress(lesson, course, status):
 
     course_details = frappe.get_doc("LMS Course", course)
     progress = course_details.get_course_progress()
-    frappe.db.set_value("LMS Batch Memebership", membership, "progress", progress)
+    frappe.db.set_value("LMS Batch Membership", membership, "progress", progress)
     return progress

--- a/community/lms/doctype/lms_batch_membership/lms_batch_membership.json
+++ b/community/lms/doctype/lms_batch_membership/lms_batch_membership.json
@@ -5,15 +5,16 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "batch",
+  "course",
   "member",
   "member_name",
   "member_username",
   "column_break_3",
-  "course",
+  "batch",
   "member_type",
-  "role",
-  "current_lesson"
+  "progress",
+  "current_lesson",
+  "role"
  ],
  "fields": [
   {
@@ -80,11 +81,18 @@
    "fieldtype": "Data",
    "label": "Memeber Username",
    "read_only": 1
+  },
+  {
+   "fieldname": "progress",
+   "fieldtype": "Data",
+   "label": "Progress",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-09-29 15:27:58.765399",
+ "migration_hash": "10fbeeba76887ba1dc94e7ac19ea637d",
+ "modified": "2021-10-20 10:08:04.071690",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch Membership",

--- a/community/lms/doctype/lms_batch_membership/lms_batch_membership.json
+++ b/community/lms/doctype/lms_batch_membership/lms_batch_membership.json
@@ -66,6 +66,7 @@
    "fieldname": "course",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Course",
    "options": "LMS Course"
   },
@@ -91,8 +92,8 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "migration_hash": "10fbeeba76887ba1dc94e7ac19ea637d",
- "modified": "2021-10-20 10:08:04.071690",
+ "migration_hash": "fe10c462acf5e727d864305d7ce90e73",
+ "modified": "2021-10-20 15:10:33.767419",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch Membership",
@@ -113,6 +114,5 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "DESC",
- "track_changes": 1
+ "sort_order": "DESC"
 }

--- a/community/lms/doctype/lms_course/lms_course.py
+++ b/community/lms/doctype/lms_course/lms_course.py
@@ -251,7 +251,7 @@ class LMSCourse(Document):
 
         membership = frappe.db.get_value("LMS Batch Membership",
                         filters,
-                        ["name", "batch", "current_lesson", "member_type"],
+                        ["name", "batch", "current_lesson", "member_type", "progress"],
                         as_dict=True)
 
         if membership and membership.batch:

--- a/community/lms/report/course_progress_summary/course_progress_summary.py
+++ b/community/lms/report/course_progress_summary/course_progress_summary.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.utils import rounded
+from frappe.utils import cint
 from frappe import _
 
 def execute(filters=None):
@@ -23,21 +23,16 @@ def get_data(filters=None):
     memberships = frappe.get_all(
                         "LMS Batch Membership",
                         query_filter,
-                        ["name", "course", "member", "member_name"],
+                        ["name", "course", "member", "member_name", "progress"],
                         order_by="course")
 
-    current_course = memberships[0].course
     for membership in memberships:
-        if current_course != membership.course:
-            current_course = membership.course
-
-        course_details = frappe.get_doc("LMS Course", current_course)
         summary.append(frappe._dict({
-            "course": course_details.name,
-            "course_name": course_details.title,
+            "course": membership.name,
+            "course_name": frappe.db.get_value("LMS Course", membership.course, "title"),
             "member": membership.member,
             "member_name": membership.member_name,
-            "progress": rounded(course_details.get_course_progress(membership.member))
+            "progress": cint(membership.progress)
         }))
 
     return summary

--- a/community/lms/widgets/CourseCard.html
+++ b/community/lms/widgets/CourseCard.html
@@ -1,5 +1,5 @@
 {% set membership = course.get_membership(frappe.session.user) %}
-{% set progress = membership.progress %}
+{% set progress = frappe.utils.cint(membership.progress) %}
 <div class="common-card-style course-card">
 
   <div class="course-image {% if not course.image %}default-image{% endif %}"

--- a/community/lms/widgets/CourseCard.html
+++ b/community/lms/widgets/CourseCard.html
@@ -1,5 +1,5 @@
 {% set membership = course.get_membership(frappe.session.user) %}
-{% set progress = course.get_course_progress() %}
+{% set progress = membership.progress %}
 <div class="common-card-style course-card">
 
   <div class="course-image {% if not course.image %}default-image{% endif %}"

--- a/community/overrides/user.py
+++ b/community/overrides/user.py
@@ -132,6 +132,7 @@ class CustomUser(User):
         completed = []
         memberships = self.get_course_membership("Student")
         for membership in memberships:
+            course = frappe.get_doc("LMS Course", membership.course)
             progress = cint(membership.progress)
             if progress < 100:
                 in_progress.append(course)

--- a/community/overrides/user.py
+++ b/community/overrides/user.py
@@ -109,7 +109,7 @@ class CustomUser(User):
         if member_type:
             filters["member_type"] = member_type
 
-        return frappe.get_all("LMS Batch Membership", filters, ["name", "course"])
+        return frappe.get_all("LMS Batch Membership", filters, ["name", "course", "progress"])
 
     def get_mentored_courses(self):
         """ Returns all courses mentored by this user """
@@ -130,10 +130,9 @@ class CustomUser(User):
     def get_enrolled_courses(self):
         in_progress = []
         completed = []
-        memberships = self.get_course_membership("Student");
+        memberships = self.get_course_membership("Student")
         for membership in memberships:
-            course = frappe.get_doc("LMS Course", membership.course)
-            progress = course.get_course_progress(member=self.name)
+            progress = cint(membership.progress)
             if progress < 100:
                 in_progress.append(course)
             else:

--- a/community/patches.txt
+++ b/community/patches.txt
@@ -18,3 +18,4 @@ execute:frappe.delete_doc("DocType", "Lessons") #06-10-2021
 execute:frappe.delete_doc("DocType", "Chapter") #06-10-2021
 execute:frappe.delete_doc("DocType", "Lesson") #06-10-2021
 execute:frappe.delete_doc("DocType", "LMS Topic") #06-10-2021
+community.patches.v0_0.add_progress_to_membership #20-10-2021

--- a/community/patches/v0_0/add_progress_to_membership.py
+++ b/community/patches/v0_0/add_progress_to_membership.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe.utils import rounded
+
+def execute():
+    frappe.reload_doc("lms", "doctype", "lms_batch_membership")
+    memberships = frappe.get_all(
+                        "LMS Batch Membership",
+                        ["name", "course", "member"],
+                        order_by="course")
+
+    if len(memberships):
+        current_course = memberships[0].course
+        for membership in memberships:
+            if current_course != membership.course:
+                current_course = membership.course
+
+            course_details = frappe.get_doc("LMS Course", current_course)
+            progress = rounded(course_details.get_course_progress(membership.member))
+            frappe.db.set_value("LMS Batch Membership", membership.name, "progress", progress)
+
+    frappe.db.delete("Prepared Report", {"ref_report_doctype": "Course Progress Summary"})
+    frappe.db.set_value("Report", "Course Progress Summary", "prepared_report", 0)

--- a/community/www/batch/learn.html
+++ b/community/www/batch/learn.html
@@ -99,7 +99,7 @@
       <img class="ml-2" src="/assets/community/icons/side-arrow-white.svg">
     </a>
     {% elif course.enable_certification %}
-    <div class="button is-primary {% if course.get_course_progress() != 100 %} hide {% endif %}" id="certification">
+    <div class="button is-primary {% if membership.progress != 100 %} hide {% endif %}" id="certification">
       Get Certificate
     </div>
     {% endif %}

--- a/community/www/courses/course.html
+++ b/community/www/courses/course.html
@@ -111,7 +111,7 @@
       </div>
       {{ widgets.MemberCard(member=course.get_instructor(), show_course_count=True, dimension_class="member-card-large") }}
     </div>
-    {% set progress = membership.progress %}
+    {% set progress = frappe.utils.cint(membership.progress) %}
     {% if progress %}
     <div class="course-progress-section">
       <div class="course-home-headings">

--- a/community/www/courses/course.html
+++ b/community/www/courses/course.html
@@ -111,7 +111,7 @@
       </div>
       {{ widgets.MemberCard(member=course.get_instructor(), show_course_count=True, dimension_class="member-card-large") }}
     </div>
-    {% set progress = course.get_course_progress() %}
+    {% set progress = membership.progress %}
     {% if progress %}
     <div class="course-progress-section">
       <div class="course-home-headings">


### PR DESCRIPTION
**Issue:**
1. Course Progress Summary report now has a huge amount of data. This results in a timeout before the report completes execution.
2. Converting it to a prepared report does not help because prepared reports can't have charts

**Fix:**
1. Added a progress field in membership doctype.

<img width="1079" alt="Screenshot 2021-10-20 at 4 20 48 PM" src="https://user-images.githubusercontent.com/31363128/138079902-95bc9287-c2b0-4a94-9287-3f7cd84c2d1c.png">

2. Added a patch to add progress in this field.
3. Now when a lesson would be marked as complete, updated progress will be calculated and saved in the field in membership doctype
4. All files that display progress will fetch data from this field.
5. Course progress summary report will also fetch progress from this field.