### PR TITLE
fix: docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,6 @@
 version: "3"
 
 services:
-  redis-cache:
-    image: redis:alpine
-  redis-queue:
-    image: redis:alpine
-  redis-socketio:
-    image: redis:alpine
   mariadb:
     image: mariadb
     volumes:
@@ -15,18 +9,15 @@ services:
       - MYSQL_ROOT_PASSWORD=root
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
   bench:
-    image: anandology/frappe-bench
+    image: anandology/frappe-bench:2021.10
     volumes:
-      - .:/home/bench/frappe-bench/apps/community
+      - .:/opt/frappe-bench/apps/community
     environment:
       - FRAPPE_APPS=community
       - FRAPPE_ALLOW_TESTS=true
       - FRAPPE_SITE_NAME=frappe.localhost
     depends_on:
       - mariadb
-      - redis-cache
-      - redis-queue
-      - redis-socketio
     ports:
       - 8000:8000
       - 9000:9000


### PR DESCRIPTION
The new image of anandology/frappe-bench has the following changes:
- the bench directoy is changed from /home/bench/frappe-bench to /opt/frappe-bench
- dependency on external redis service is removed

Updated the docker-compose.yml to reflect these changes. Also pinned the
docker image to anandology/frappe-bench:2021.10

This doesn't include the rename of community to school, which is already present in PR #238. This will merge with that without conflicts.