### PR TITLE
style: course cards, card dividers, breadcrumbs

### DIFF
--- a/school/lms/report/course_progress_summary/course_progress_summary.js
+++ b/school/lms/report/course_progress_summary/course_progress_summary.js
@@ -8,7 +8,8 @@ frappe.query_reports["Course Progress Summary"] = {
 			"fieldname": "course",
 			"label": __("Course"),
 			"fieldtype": "Link",
-			"options": "LMS Course"
+			"options": "LMS Course",
+			"reqd": 1,
 		}
 	]
 };

--- a/school/lms/widgets/CourseCard.html
+++ b/school/lms/widgets/CourseCard.html
@@ -51,13 +51,13 @@
     </span>
     <span class="course-student-count">
       {% if course.get_students() | length %}
-      <span class="mr-4">
+      <span class="vertically-center  mr-4">
         <img class="icon-background" src="/assets/school/icons/user.svg" />
         {{ course.get_students() | length }}
       </span> {% endif %}
       {% set avg_rating = course.get_average_rating() %}
       {% if avg_rating %}
-      <span class="">
+      <span class="vertically-center ">
         <img class="icon-background" src="/assets/school/icons/rating.svg" />
         {{ frappe.utils.flt(avg_rating, frappe.get_system_settings("float_precision") or 3) }}
       </span>
@@ -77,36 +77,36 @@
 
   {% if certificate %}
   <div class="view-course-link is-default">
-    _("Get Certificate") <img class="ml-3" src="/assets/school/icons/black-arrow.svg" />
+    _("Get Certificate") <img class="ml-1" src="/assets/school/icons/black-arrow.svg" />
   </div>
   <a class="stretched-link" href="/courses/{{ course.name }}/{{ certificate }}"></a>
 
   {% elif course.enable_certification and progress == 100 %}
   <div class="view-course-link is-default" id="certification" data-course="{{ course.name }}">
-    {{ _("Get Certificate") }} <img class="ml-3" src="/assets/school/icons/black-arrow.svg" />
+    {{ _("Get Certificate") }} <img class="ml-1" src="/assets/school/icons/black-arrow.svg" />
   </div>
 
   {% elif progress == 100 %}
   <div class="view-course-link is-default">
-    {{ _("Course Completed") }} <img class="ml-3" src="/assets/school/icons/black-arrow.svg" />
+    {{ _("Course Completed") }} <img class="ml-1" src="/assets/school/icons/black-arrow.svg" />
   </div>
   <a class="stretched-link" href="/courses/{{ course.name }}"></a>
 
   {% elif course.upcoming %}
   <div class="view-course-link is-secondary border">
-    {{ _("Upcoming Course") }} <img class="ml-3" src="/assets/school/icons/black-arrow.svg" />
+    {{ _("Upcoming Course") }} <img class="ml-1" src="/assets/school/icons/black-arrow.svg" />
   </div>
   <a class="stretched-link" href="/courses/{{ course.name }}"></a>
 
   {% elif membership %}
   <div class="view-course-link is-primary">
-    {{ _("Continue Course") }} <img class="ml-3" src="/assets/school/icons/white-arrow.svg" />
+    {{ _("Continue Course") }} <img class="ml-1" src="/assets/school/icons/white-arrow.svg" />
   </div>
   <a class="stretched-link" href="{{ course.get_learn_url(lesson_index) }}{{ query_parameter }}"></a>
 
   {% else %}
   <div class="view-course-link is-default">
-    {{ _("View Course") }} <img class="ml-3" src="/assets/school/icons/black-arrow.svg" />
+    {{ _("View Course") }} <img class="ml-1" src="/assets/school/icons/black-arrow.svg" />
   </div>
   <a class="stretched-link" href="/courses/{{ course.name }}"></a>
 

--- a/school/lms/widgets/CourseCard.html
+++ b/school/lms/widgets/CourseCard.html
@@ -51,13 +51,13 @@
     </span>
     <span class="course-student-count">
       {% if course.get_students() | length %}
-      <span class="vertically-center  mr-4">
+      <span class="vertically-center mr-4">
         <img class="icon-background" src="/assets/school/icons/user.svg" />
         {{ course.get_students() | length }}
       </span> {% endif %}
       {% set avg_rating = course.get_average_rating() %}
       {% if avg_rating %}
-      <span class="vertically-center ">
+      <span class="vertically-center">
         <img class="icon-background" src="/assets/school/icons/rating.svg" />
         {{ frappe.utils.flt(avg_rating, frappe.get_system_settings("float_precision") or 3) }}
       </span>

--- a/school/public/css/style.css
+++ b/school/public/css/style.css
@@ -151,12 +151,12 @@ input[type=checkbox] {
 }
 
 .card-divider {
-  border: 1px solid #EEF0F2;
+  border-top: 1px solid #EEF0F2;
   margin-bottom: 1rem;
 }
 
 .card-divider-dark {
-  border: 1px solid #C8CFD5;
+  border-top: 1px solid #C8CFD5;
   margin-bottom: 16px;
 }
 
@@ -168,8 +168,8 @@ input[type=checkbox] {
 }
 
 .course-student-count {
+  display: flex;
   font-size: 12px;
-  line-height: 135%;
   float: right;
 }
 
@@ -907,7 +907,6 @@ input[type=checkbox] {
 }
 
 .breadcrumb {
-  padding: 0 1rem;
   display: flex;
   align-items: center;
   font-size: 12px;
@@ -1375,4 +1374,9 @@ pre {
   box-sizing: border-box;
   border-radius: 8px;
   padding: 2.5rem;
+}
+
+.vertically-center {
+  display: flex;
+  align-items: center;
 }


### PR DESCRIPTION
1. Improved alignment for course cards.
2. Reduced space between CTA label and arrow.

<img width="423" alt="Screenshot 2021-11-01 at 1 26 46 PM" src="https://user-images.githubusercontent.com/31363128/139640748-9acb8bfb-8107-42da-958a-aae30026ce74.png">


3. Removed padding around breadcrumb.
4. Made card divider thinner.

<img width="1000" alt="Screenshot 2021-11-01 at 1 35 49 PM" src="https://user-images.githubusercontent.com/31363128/139640773-f194b367-7f8f-4c25-9a13-49b6edbacb27.png">