### PR TITLE
style: better empty states

### DIFF
--- a/school/lms/web_template/courses_enrolled/courses_enrolled.html
+++ b/school/lms/web_template/courses_enrolled/courses_enrolled.html
@@ -16,7 +16,7 @@
   {% set site_name = frappe.db.get_single_value("System Settings", "app_name") %}
   <div class="empty-state">
     <div class="course-home-headings text-center mb-0" style="color: inherit;">You haven't enrolled for any courses</div>
-    <p class="text-center mb-8">Here are a few courses we recommend for you to get started with {{ site_name }}</p>
+    <p class="small text-center mb-8">Here are a few courses we recommend for you to get started with {{ site_name }}</p>
     {% set recommended_courses = [course1, course2, course3] %}
     <div class="cards-parent">
     {% for recommended_course in recommended_courses %}

--- a/school/lms/widgets/Reviews.html
+++ b/school/lms/widgets/Reviews.html
@@ -38,7 +38,7 @@
 
   {% else %}
   <div class="empty-state text-center">
-    <svg class="icon icon-xl"><use href="#icon-small-message"></use></svg>
+    <img class="icon icon-xl" src="/assets/frappe/icons/timeless/message.svg">
     <div class="course-home-headings mt-4 mb-0" style="color: inherit;"> {{ _("Review the course") }} </div>
     <div class="small mb-6"> {{ _("Help us improve our course material.") }} </div>
     {% if course.is_eligible_to_review(membership) %}
@@ -46,7 +46,7 @@
         Write a review
       </span>
     {% elif frappe.session.user == "Guest" %}
-    <div class="button is-secondary ml-auto mr-auto mt-3"> {{ _("Login") }} </div>
+    <a class="button is-secondary dark-links ml-auto mr-auto mt-3" href="/login?redirect-to=/courses/{{ course.name }}"> {{ _("Login") }} </a>
     {% elif not membership %}
     <div class="button is-secondary join-batch ml-auto mr-auto mt-3" data-course="{{ course.name | urlencode }}"> {{ _("Start Learning") }} </div>
     {% endif %}

--- a/school/lms/widgets/Reviews.html
+++ b/school/lms/widgets/Reviews.html
@@ -37,18 +37,19 @@
   </div>
 
   {% else %}
-  <div class="common-card-style thread-card">
-    <div class="w-25 text-center" style="margin: 0 auto;">
-      <span class="font-weight-bold"> No Reviews </span>
-      <div class="small">
-        There are no reviews for this course.
-      </div>
-      {% if course.is_eligible_to_review(membership) %}
+  <div class="empty-state text-center">
+    <svg class="icon icon-xl"><use href="#icon-small-message"></use></svg>
+    <div class="course-home-headings mt-4 mb-0" style="color: inherit;"> {{ _("Review the course") }} </div>
+    <div class="small mb-6"> {{ _("Help us improve our course material.") }} </div>
+    {% if course.is_eligible_to_review(membership) %}
       <span class="review-link button is-secondary ml-auto mr-auto mt-3">
         Write a review
       </span>
-      {% endif %}
-    </div>
+    {% elif frappe.session.user == "Guest" %}
+    <div class="button is-secondary ml-auto mr-auto mt-3"> {{ _("Login") }} </div>
+    {% elif not membership %}
+    <div class="button is-secondary join-batch ml-auto mr-auto mt-3" data-course="{{ course.name | urlencode }}"> {{ _("Start Learning") }} </div>
+    {% endif %}
   </div>
   {% endif %}
 </div>

--- a/school/www/batch/learn.html
+++ b/school/www/batch/learn.html
@@ -113,9 +113,11 @@
 {% set condition = is_instructor if is_instructor else membership %}
 {% set doctype, docname = "Course Lesson", lesson.name %}
 {% set title = "Questions" %}
-{% set cta_title = "New Question" %}
+{% set cta_title = "Ask a Question" %}
 {% set button_name = "Start Learning" %}
 {% set redirect_to = "/courses/" + course.name %}
+{% set empty_state_title = "Have a doubt?" %}
+{% set empty_state_subtitle = "Post it here, our mentors will help you out." %}
 
 {% include "frappe/templates/discussions/discussions_section.html" %}
 {% endmacro %}


### PR DESCRIPTION
Improve empty states for:

- [x] Discussions
- [x] Reviews
- [x] Courses Enrolled template

**Reviews:**

<img width="1440" alt="Screenshot 2021-11-08 at 4 56 45 PM" src="https://user-images.githubusercontent.com/31363128/140734170-f99a0b10-54b1-4c1e-b31c-5b381e40ddaf.png">

**Discussions:**

<img width="1440" alt="Screenshot 2021-11-08 at 4 56 34 PM" src="https://user-images.githubusercontent.com/31363128/140734191-610de506-484f-4ee1-bff3-e257cfcc581d.png">

**Course Enrolment Template:**

1. Reduced font size for the byline.

<img width="1100" alt="Screenshot 2021-11-08 at 5 00 01 PM" src="https://user-images.githubusercontent.com/31363128/140734543-1a054fa7-9ec2-4f70-890b-973c68159e99.png">

**Depends on** https://github.com/frappe/frappe/pull/14916