### PR TITLE
fix: mark as complete behaviour

### DIFF
--- a/school/public/css/style.css
+++ b/school/public/css/style.css
@@ -1487,3 +1487,32 @@ pre {
 .live-courses .course-home-headings {
   margin-bottom: 1.5rem;
 }
+
+@media (min-width: 768px) {
+  .lesson-pagination .custom-checkbox .empty-checkbox {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 4px;
+  }
+}
+
+@media (max-width: 767px) {
+  .lesson-pagination .custom-checkbox .empty-checkbox {
+    margin-bottom: 1rem;
+    border-radius: 4px;
+  }
+
+  .lesson-pagination .custom-checkbox span {
+    display: inline-block;
+    width: 70%;
+    font-size: 10px;
+  }
+}
+
+.lesson-pagination .custom-checkbox input:checked+.empty-checkbox {
+  background-size: 1rem;
+}
+
+.no-discussion {
+  width: 80%;
+}

--- a/school/public/css/style.css
+++ b/school/public/css/style.css
@@ -1513,6 +1513,6 @@ pre {
   background-size: 1rem;
 }
 
-.no-discussion {
-  width: 80%;
+.no-discussions {
+  width: 80% !important;
 }

--- a/school/www/batch/learn.html
+++ b/school/www/batch/learn.html
@@ -84,7 +84,7 @@
     <label class="quiz-label">
       <input class="option mark-progress" type="checkbox" checked>
       <img class="empty-checkbox" />
-      <span class="small">{{ _("Mark the lesson as complete on moving to next lesson") }}</span>
+      <span class="small">{{ _("Mark as complete when moving to the next lesson") }}</span>
     </label>
   </div>
 

--- a/school/www/batch/learn.html
+++ b/school/www/batch/learn.html
@@ -79,27 +79,30 @@
 
 
   {% if not course.is_mentor(frappe.session.user) and membership %}
-
-  {% if course.get_progress(lesson.name) != "Complete" %}
-  <div class="button is-secondary" id="progress" data-progress="Complete">
-    Mark as Complete
+  {% set progress = course.get_progress(lesson.name) %}
+  <div class="custom-checkbox {% if progress == 'Complete' %} hide {% endif %}">
+    <label class="quiz-label">
+      <input class="option mark-progress" type="checkbox" checked>
+      <img class="empty-checkbox" />
+      <span class="small">{{ _("Mark the lesson as complete on moving to next lesson") }}</span>
+    </label>
   </div>
-  {% else %}
-  <div class="button is-secondary" id="progress" data-progress="Incomplete">
+
+  <div class="button is-secondary mark-progress {{ progress }} {% if progress == 'Incomplete' or progress == None %} hide {% endif %}"
+    data-progress="Incomplete">
     Mark as Incomplete
   </div>
-  {% endif %}
 
   {% endif %}
 
   <div>
-    {% if next_url %}
-    <a class="button is-primary next" href="{{ next_url }}">
-      Next
+    <a class="button is-primary next {% if membership.progress|int == 100 and not next_url %} hide {% endif %}"
+      {% if next_url %} data-href="{{ next_url }}" {% endif %} href="">
+      {% if next_url %} Next {% else %} Mark as Complete {% endif %}
       <img class="ml-2" src="/assets/school/icons/side-arrow-white.svg">
     </a>
-    {% elif course.enable_certification %}
-    <div class="button is-primary {% if membership.progress != 100 %} hide {% endif %}" id="certification">
+    {% if course.enable_certification %}
+    <div class="button is-primary {% if membership.progress|int != 100 or next_url %} hide {% endif %}" id="certification">
       Get Certificate
     </div>
     {% endif %}


### PR DESCRIPTION
**Issue:**
Previously, marking a lesson as complete was a manual process. Users had to click a separate button to mark the lesson as complete. Most users did not do it resulting in the loss of important information.

**Fix:**

<img width="922" alt="Screenshot 2021-11-29 at 4 07 17 PM" src="https://user-images.githubusercontent.com/31363128/143853121-ce3255b4-cc2c-4ae2-9bfe-e7b48d8afcc8.png">

We have made marking the lesson as complete a bit less manual. Instead of a button, it will now be a checkbox that will be checked by default. When users move to the next lesson, the current lesson will be marked as complete.

To not mark a lesson as complete, they can uncheck the checkbox.