### PR TITLE
feat: hide primary contact from profile

### DIFF
--- a/school/lms/doctype/lms_settings/lms_settings.json
+++ b/school/lms/doctype/lms_settings/lms_settings.json
@@ -7,6 +7,7 @@
  "field_order": [
   "livecode_url",
   "email_sender",
+  "hide_primary_contact",
   "column_break_2",
   "force_profile_completion",
   "show_search",
@@ -82,12 +83,18 @@
    "label": "Terms of Use Page",
    "mandatory_depends_on": "terms_of_use",
    "options": "Web Page"
+  },
+  {
+   "default": "0",
+   "fieldname": "hide_primary_contact",
+   "fieldtype": "Check",
+   "label": "Hide Primary Contact on Profile Page"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-12-21 16:01:48.260411",
+ "modified": "2021-12-23 19:49:02.194513",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",

--- a/school/www/profiles/profile.html
+++ b/school/www/profiles/profile.html
@@ -239,11 +239,11 @@
   <div class="course-home-headings"> {{ _("Contact") }} </div>
   <div class="common-card-style overview-card">
 
-    {% if not member.hide_private %}
+    {% if not member.hide_private and not hide_primary_contact %}
     <a class="button-links" href="mailto:{{ member.email }}"> <img src="/assets/school/icons/mail.svg"> {{ member.email }} </a>
     {% endif %}
 
-    {% if member.mobile_no and not member.hide_private %}
+    {% if member.mobile_no and not member.hide_private and not hide_primary_contact %}
     <a class="button-links" href="tel:{{ member.mobile_no }}" >
       <img src="/assets/school/icons/call.svg"> {{ member.mobile_no }}
     </a>

--- a/school/www/profiles/profile.py
+++ b/school/www/profiles/profile.py
@@ -17,6 +17,7 @@ def get_context(context):
     except:
         context.template = "www/404.html"
         return
+    context.hide_primary_contact = frappe.db.get_single_value("LMS Settings", "hide_primary_contact")
     context.profile_tabs = get_profile_tabs(context.member)
 
 def get_profile_tabs(user):


### PR DESCRIPTION
Platform maintainers can now configure if the user's primary contact information like their Email address and Mobile Number should be visible on their profile page.

They have to enable **Hide Primary Contact from Profile Page** from **LMS Settings** for the same.

<img width="1303" alt="Screenshot 2021-12-23 at 7 59 29 PM" src="https://user-images.githubusercontent.com/31363128/147254463-30883f68-e73a-42d8-88d6-09be0c9cedc3.png">

