### PR TITLE
fix: rating field issue

### DIFF
--- a/school/lms/doctype/lms_course/lms_course.py
+++ b/school/lms/doctype/lms_course/lms_course.py
@@ -312,8 +312,15 @@ class LMSCourse(Document):
                     },
                     ["review", "rating", "owner"],
                     order_by= "creation desc")
-
+        out_of_ratings = frappe.db.get_all("DocField",
+            {
+                "parent": "LMS Course Review",
+                "fieldtype": "Rating"
+            },
+            ["options"])
+        out_of_ratings = (len(out_of_ratings) and out_of_ratings[0].options) or 5
         for review in reviews:
+            review.rating = review.rating * out_of_ratings
             review.owner_details = frappe.get_doc("User", review.owner)
 
         return reviews

--- a/school/lms/doctype/lms_course_review/lms_course_review.py
+++ b/school/lms/doctype/lms_course_review/lms_course_review.py
@@ -3,12 +3,21 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import cint
 
 class LMSCourseReview(Document):
 	pass
 
 @frappe.whitelist()
 def submit_review(rating, review, course):
+    out_of_ratings = frappe.db.get_all("DocField",
+            {
+                "parent": "LMS Course Review",
+                "fieldtype": "Rating"
+            },
+            ["options"])
+    out_of_ratings = (len(out_of_ratings) and out_of_ratings[0].options) or 5
+    rating = cint(rating)/out_of_ratings
     frappe.get_doc({
         "doctype": "LMS Course Review",
         "rating": rating,

--- a/school/www/courses/course.js
+++ b/school/www/courses/course.js
@@ -192,10 +192,7 @@ var submit_review = (e) => {
     callback: (data) => {
       if (data.message == "OK") {
         $(".review-modal").modal("hide");
-        frappe.msgprint("Thanks for providing your feedback!");
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
+        window.location.reload();
       }
     }
   })


### PR DESCRIPTION
**Issue:**
1. Frappe now has [Fractional Ratings](https://github.com/frappe/frappe/pull/15426).
2. Because of this on the course page the ratings were not reflected properly.

<img width="1317" alt="Screenshot 2021-12-27 at 1 30 26 PM" src="https://user-images.githubusercontent.com/31363128/147449450-0e1fd94a-d550-4015-8968-365c88190ea1.png">

<img width="277" alt="Screenshot 2021-12-27 at 1 30 30 PM" src="https://user-images.githubusercontent.com/31363128/147449459-9b79ebca-525d-4cbd-b126-500e753d8e9c.png">

**Fix:**
1. Adjusted out rating display to consider the rating field options if present else considers it as 5 and compute the ratings.

<img width="287" alt="Screenshot 2021-12-27 at 1 23 50 PM" src="https://user-images.githubusercontent.com/31363128/147449527-1e53d515-6f0e-45e8-99b1-d351a04ec9da.png">

<img width="435" alt="Screenshot 2021-12-27 at 1 23 56 PM" src="https://user-images.githubusercontent.com/31363128/147449531-6986cd7a-6935-4903-bddb-69f554d209c6.png">

