### PR TITLE
fix: profile page sections

### DIFF
--- a/school/overrides/user.py
+++ b/school/overrides/user.py
@@ -71,8 +71,8 @@ class CustomUser(User):
                 frappe.throw(_("Skills must be unique"))
 
     def validate_completion(self):
-        all_fields_have_value = True
         if frappe.db.get_single_value("LMS Settings", "force_profile_completion"):
+            all_fields_have_value = True
             profile_mandatory_fields = frappe.get_hooks("profile_mandatory_fields")
             docfields = frappe.get_meta(self.doctype).fields
 
@@ -81,7 +81,7 @@ class CustomUser(User):
                     all_fields_have_value = False
                     break
 
-        self.profile_complete = all_fields_have_value
+            self.profile_complete = all_fields_have_value
 
     def get_authored_courses(self) -> int:
         """Returns the number of courses authored by this user.

--- a/school/www/profiles/profile.html
+++ b/school/www/profiles/profile.html
@@ -81,20 +81,20 @@
     <div class="common-card-style overview-card small-title">
       {% if enrollment %}
       <div class="overview-item">
-        <img class="icon-background mr-1" src="/assets/school/icons/course.svg" />
-        {{ enrollment }} {% if enrollment > 1 %} Courses {% else %} Course {% endif %} Taken
+        <img class="mr-1" src="/assets/school/icons/course.svg" />
+        <span> {{ enrollment }} {% if enrollment > 1 %} Courses {% else %} Course {% endif %} Taken </span>
       </div>
       {% endif %}
       {% if reviews %}
       <div class="overview-item">
-        <img class="icon-background mr-1" src="/assets/school/icons/rating.svg" />
-        {{ reviews }} {% if reviews > 1 %} Courses {% else %} Course {% endif %} Reviewed
+        <img class="mr-1" src="/assets/school/icons/rating.svg" />
+        <span> {{ reviews }} {% if reviews > 1 %} Courses {% else %} Course {% endif %} Reviewed </span>
       </div>
       {% endif %}
       {% if mentorship %}
       <div class="overview-item">
-        <img class="icon-background mr-1" src="/assets/school/icons/calendar.svg" />
-        {{ mentorship }} {% if mentorship > 1 %} Courses {% else %} Course {% endif %} Mentored
+        <img class="mr-1" src="/assets/school/icons/calendar.svg" />
+        <span> {{ mentorship }} {% if mentorship > 1 %} Courses {% else %} Course {% endif %} Mentored </span>
       </div>
       {% endif %}
     </div>
@@ -238,6 +238,7 @@
 {% endmacro %}
 
 {% macro Contact(member) %}
+{% if not hide_primary_contact and member.email and member.mobile_no and member.linkedin and member.github and member.medium %}
 <div class="education-details">
   <div class="course-home-headings"> {{ _("Contact") }} </div>
   <div class="common-card-style overview-card">
@@ -269,6 +270,7 @@
     {% endif %}
   </div>
 </div>
+{% endif %}
 {% endmacro %}
 
 {% macro Skills(member) %}

--- a/school/www/profiles/profile.html
+++ b/school/www/profiles/profile.html
@@ -238,7 +238,7 @@
 {% endmacro %}
 
 {% macro Contact(member) %}
-{% if not hide_primary_contact and member.email and member.mobile_no and member.linkedin and member.github and member.medium %}
+{% if show_contacts_section %}
 <div class="education-details">
   <div class="course-home-headings"> {{ _("Contact") }} </div>
   <div class="common-card-style overview-card">

--- a/school/www/profiles/profile.py
+++ b/school/www/profiles/profile.py
@@ -18,7 +18,15 @@ def get_context(context):
         context.template = "www/404.html"
         return
     context.hide_primary_contact = frappe.db.get_single_value("LMS Settings", "hide_primary_contact")
+    context.show_contacts_section = show_contacts_section(context.member, context.hide_primary_contact)
     context.profile_tabs = get_profile_tabs(context.member)
+
+def show_contacts_section(member, hide_primary_contact):
+    if member.github or member.linkedin or member.medium:
+        return True
+    if hide_primary_contact or member.hide_private:
+        return False
+    return True
 
 def get_profile_tabs(user):
     """Returns the enabled ProfileTab objects.


### PR DESCRIPTION
1. Not showing empty Contacts section if there is no information in it.

<img width="291" alt="Screenshot 2022-01-03 at 10 12 16 AM" src="https://user-images.githubusercontent.com/31363128/147900247-409fc7ca-70c1-4441-9703-df45522fd8d3.png">

2. Increasing icons size on the overview section.

<img width="296" alt="Screenshot 2022-01-03 at 9 59 48 AM" src="https://user-images.githubusercontent.com/31363128/147900256-f924bda2-4993-47c2-b3a2-97ee894288cb.png">

3. Improved condition for profile completion