### PR TITLE
fix: Exclude disabled users from Community Page

### DIFF
--- a/school/overrides/user.py
+++ b/school/overrides/user.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe.core.doctype.user.user import User
-from frappe.utils import cint, escape_html, random_string, unique
+from frappe.utils import cint, escape_html, random_string
 import hashlib
 import random
 import re
@@ -274,7 +274,7 @@ def get_or_filters(text):
         or_filters.append(f"pi.industry like '%{text}%'")
 
 
-    return "AND {}".format(" OR ".join(or_filters)) if or_filters else ""
+    return "AND ({})".format(" OR ".join(or_filters)) if or_filters else ""
 
 def get_user_details(users):
     user_details = []


### PR DESCRIPTION
**Before:**

Community Page was showing disabled users.
<img width="1327" alt="Screenshot 2022-01-06 at 9 26 46 PM" src="https://user-images.githubusercontent.com/31363128/148412322-810e3bf2-e897-4be6-9cfc-5f33f3e6b773.png">

**After:**
<img width="1350" alt="Screenshot 2022-01-06 at 9 28 23 PM" src="https://user-images.githubusercontent.com/31363128/148412372-7a08fb8f-decb-4d0b-be77-ba6654c9d695.png">

