### PR TITLE
fix: jobs ui and reporting

### DIFF
--- a/school/job/doctype/job_opportunity/job_opportunity.json
+++ b/school/job/doctype/job_opportunity/job_opportunity.json
@@ -9,10 +9,10 @@
  "field_order": [
   "job_title",
   "location",
+  "disabled",
   "column_break_5",
   "type",
   "status",
-  "job_opportunity_status",
   "section_break_6",
   "description",
   "company_details_section",
@@ -51,19 +51,12 @@
    "reqd": 1
   },
   {
-   "default": "Pending",
+   "default": "Open",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Pending\nApproved\nRejected"
-  },
-  {
-   "default": "Open",
-   "fieldname": "job_opportunity_status",
-   "fieldtype": "Select",
-   "label": "Job Opportunity Status",
    "options": "Open\nClosed"
   },
   {
@@ -109,11 +102,17 @@
    "fieldtype": "Data",
    "label": "Application Form Link",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-12-30 12:10:08.849547",
+ "modified": "2022-01-11 14:56:42.509351",
  "modified_by": "Administrator",
  "module": "Job",
  "name": "Job Opportunity",

--- a/school/job/doctype/job_opportunity/job_opportunity.py
+++ b/school/job/doctype/job_opportunity/job_opportunity.py
@@ -12,14 +12,15 @@ class JobOpportunity(Document):
 
 @frappe.whitelist()
 def report(job, reason):
+    system_managers = get_system_managers(only_name=True)
+    subject = _("User {0} has reported the job post {1}").format(user, job)
+    user = frappe.db.get_value("User", frappe.session.user, "full_name")
     args = {
         "job": job,
         "job_url": get_link_to_form("Job Opportunity", job),
-        "user": frappe.session.user
+        "user": user,
+        "reason": reason
     }
-    system_managers = get_system_managers(only_name=True)
-    user = frappe.db.get_value("User", frappe.session.user, "full_name")
-    subject = _("User {0} has reported the job post {1}").format(user, job)
     frappe.sendmail(
         recipients = system_managers,
         subject=subject,

--- a/school/job/doctype/job_opportunity/job_opportunity.py
+++ b/school/job/doctype/job_opportunity/job_opportunity.py
@@ -1,8 +1,29 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.utils.user import get_system_managers
+from frappe import _
+from frappe.utils import get_link_to_form
 
 class JobOpportunity(Document):
 	pass
+
+@frappe.whitelist()
+def report(job, reason):
+    args = {
+        "job": job,
+        "job_url": get_link_to_form("Job Opportunity", job),
+        "user": frappe.session.user
+    }
+    system_managers = get_system_managers(only_name=True)
+    user = frappe.db.get_value("User", frappe.session.user, "full_name")
+    subject = _("User {0} has reported the job post {1}").format(user, job)
+    frappe.sendmail(
+        recipients = system_managers,
+        subject=subject,
+        header=[subject, "green"],
+        template = "job_report",
+        args=args,
+        now=True)

--- a/school/job/doctype/job_opportunity/job_opportunity.py
+++ b/school/job/doctype/job_opportunity/job_opportunity.py
@@ -13,8 +13,8 @@ class JobOpportunity(Document):
 @frappe.whitelist()
 def report(job, reason):
     system_managers = get_system_managers(only_name=True)
-    subject = _("User {0} has reported the job post {1}").format(user, job)
     user = frappe.db.get_value("User", frappe.session.user, "full_name")
+    subject = _("User {0} has reported the job post {1}").format(user, job)
     args = {
         "job": job,
         "job_url": get_link_to_form("Job Opportunity", job),

--- a/school/job/doctype/job_settings/job_settings.js
+++ b/school/job/doctype/job_settings/job_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Job Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/school/job/doctype/job_settings/job_settings.json
+++ b/school/job/doctype/job_settings/job_settings.json
@@ -1,0 +1,42 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-01-10 17:16:46.598673",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "allow_posting"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "allow_posting",
+   "fieldtype": "Check",
+   "label": "Allow Job Posting From Website"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-01-10 18:45:26.646438",
+ "modified_by": "Administrator",
+ "module": "Job",
+ "name": "Job Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/school/job/doctype/job_settings/job_settings.py
+++ b/school/job/doctype/job_settings/job_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class JobSettings(Document):
+	pass

--- a/school/job/doctype/job_settings/test_job_settings.py
+++ b/school/job/doctype/job_settings/test_job_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestJobSettings(unittest.TestCase):
+	pass

--- a/school/public/css/style.css
+++ b/school/public/css/style.css
@@ -1479,16 +1479,26 @@ pre {
 }
 
 .job-card-info {
-  padding: 0 1.5rem;
   flex: 1;
 }
 
 .company-logo {
   background-position: center;
-  background-size: 88px;
+  background-size: 37px;
 }
 
 .job-card-parent {
   display: grid;
   row-gap: 1rem;
+}
+
+.job-card-logo-section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.job-detail-card {
+  flex-direction: column;
 }

--- a/school/public/css/style.css
+++ b/school/public/css/style.css
@@ -63,9 +63,8 @@ input[type=checkbox] {
   text-align: center;
   letter-spacing: 0.011em;
   text-transform: uppercase;
-  color: #2C5477;
   font-weight: bold;
-  box-shadow: 0px 5px 10px rgb(0 0 0 / 10%);
+  box-shadow: var(--shadow-base);
 }
 
 .dark-pills {
@@ -119,9 +118,7 @@ input[type=checkbox] {
 
 .card-heading {
   font-weight: 600;
-  font-size: 1.5rem;
-  line-height: 156%;
-  letter-spacing: -0.014em;
+  font-size: var(--text-3xl);
   color: var(--text-color-dark);
 }
 
@@ -1478,20 +1475,20 @@ pre {
 
 .job-card {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-right: 1rem;
-}
-
-.job-card-info {
-  padding: 2rem 1rem 1rem;
-}
-
-.job-description-section {
   padding: 1rem;
 }
 
+.job-card-info {
+  padding: 0 1.5rem;
+  flex: 1;
+}
+
 .company-logo {
-  background-position: left;
+  background-position: center;
   background-size: 88px;
+}
+
+.job-card-parent {
+  display: grid;
+  row-gap: 1rem;
 }

--- a/school/templates/emails/job_report.html
+++ b/school/templates/emails/job_report.html
@@ -1,7 +1,6 @@
 {% set job_link = "<a href='" + job_url + "'>" + job + "</a>" %}
 
-
 <p>{{ _("Hey,") }}</p>
 <p>{{ _("{0} has reported a job post for the following reason.").format(user) }}</p>
 <p>{{ reason }}</p>
-<p>{{ _("Please take appropriate action at {0}").format(job_link) }}</p>
+<p>{{ _("Please take appropriate action at {0}").format(job_url) }}</p>

--- a/school/templates/emails/job_report.html
+++ b/school/templates/emails/job_report.html
@@ -2,5 +2,5 @@
 
 <p>{{ _("Hey,") }}</p>
 <p>{{ _("{0} has reported a job post for the following reason.").format(user) }}</p>
-<p>{{ reason }}</p>
+<p>" {{ reason }} "</p>
 <p>{{ _("Please take appropriate action at {0}").format(job_url) }}</p>

--- a/school/templates/emails/job_report.html
+++ b/school/templates/emails/job_report.html
@@ -1,0 +1,7 @@
+{% set job_link = "<a href='" + job_url + "'>" + job + "</a>" %}
+
+
+<p>{{ _("Hey,") }}</p>
+<p>{{ _("{0} has reported a job post for the following reason.").format(user) }}</p>
+<p>{{ reason }}</p>
+<p>{{ _("Please take appropriate action at {0}").format(job_link) }}</p>

--- a/school/templates/job_card.html
+++ b/school/templates/job_card.html
@@ -1,0 +1,21 @@
+<div class="job-card">
+  <div class="job-card-info">
+    <div class="d-flex mb-3">
+      <div class="course-card-pills">{{ _(job.type) }}</div>
+      <div class="course-card-pills">{{ job.location }}</div>
+    </div>
+    <div class="card-heading">{{ _(job.job_title) }}</div>
+    <div class="mt-1">
+      <a class="dark-links" href="{{ job.company_website }}">{{ job.company_name }}</a>
+    </div>
+    {% if show_edit_link and job.owner == frappe.session.user %}
+    <a href="/job-opportunity?name={{ job.name }}">Edit</a>
+    {% endif %}
+  </div>
+  <div class="job-card-logo-section">
+    <div class="small">Posted on: {{ frappe.utils.format_date(job.creation, "medium") }}</div>
+    <div class="avatar avatar-medium" title="{{ job.company_name}}">
+      <span class="avatar-frame company-logo" style="background-image: url( {{ job.company_logo | urlencode }} );"></span>
+    </div>
+  </div>
+</div>

--- a/school/www/community/index.html
+++ b/school/www/community/index.html
@@ -1,5 +1,4 @@
 {% extends "templates/base.html" %}
-{% from "www/hackathons/macros/card.html" import null_card %}
 {% block title %}{{ _('Community') }}{% endblock %}
 
 {% block content %}

--- a/school/www/courses/index.html
+++ b/school/www/courses/index.html
@@ -1,5 +1,4 @@
 {% extends "templates/base.html" %}
-{% from "www/hackathons/macros/card.html" import null_card %}
 {% block title %}{{ 'Courses' }}{% endblock %}
 {% block head_include %}
 <style>

--- a/school/www/jobs/index.html
+++ b/school/www/jobs/index.html
@@ -1,5 +1,4 @@
 {% extends "templates/base.html" %}
-{% from "www/hackathons/macros/card.html" import null_card %}
 {% block title %}{{ _('Job Openings') }}{% endblock %}
 
 {% block content %}
@@ -16,20 +15,8 @@
   <div class="job-card-parent">
       {% for job in jobs %}
         <div class="common-card-style course-card">
-          <div class="job-card">
-            <div class="avatar avatar-large" title="{{ job.company_name}}">
-              <span class="avatar-frame company-logo" style="background-image: url( {{ job.company_logo | urlencode }} );"></span>
-            </div>
-            <div class="job-card-info">
-              <div class="d-flex mb-1">
-                <div class="course-card-pills">{{ _(job.type) }}</div>
-                <div class="course-card-pills">{{ job.location }}</div>
-              </div>
-              <div class="card-heading">{{ _(job.job_title) }}</div>
-              <div>{{ job.company_name }}</div>
-            </div>
-            <div class="small">Posted on: {{ frappe.utils.format_date(job.creation, "medium") }}</div>
-          </div>
+          {% set show_edit_link = False %}
+          {% include "school/templates/job_card.html" %}
           <a class="stretched-link" href="/jobs/{{ job.name }}"></a>
         </div>
       {% endfor %}
@@ -37,8 +24,8 @@
     {% else %}
     <div class="empty-state text-center">
       <img class="icon icon-xl" src="/assets/frappe/icons/timeless/message.svg">
-      <div class="course-home-headings mt-4 mb-0" style="color: inherit;"> {{ _("No open positions") }} </div>
-      <div class="small mb-6"> {{ _("There are no job openings available.") }} </div>
+      <div class="course-home-headings mt-4 mb-0" style="color: inherit;"> {{ _("No open jobs") }} </div>
+      <div class="small mb-6"> {{ _("There are no job openings at present.") }} </div>
       {% if allow_posting %}
       <a class="button is-secondary dark-links m-auto" href="/job-opportunity?new=1">{{ _("Post a Job") }}</a>
       {% endif %}

--- a/school/www/jobs/index.html
+++ b/school/www/jobs/index.html
@@ -3,32 +3,47 @@
 {% block title %}{{ _('Job Openings') }}{% endblock %}
 
 {% block content %}
+{% set allow_posting = frappe.db.get_single_value("Job Settings", "allow_posting") %}
 <div class="common-page-style">
   <div class="container">
-  <a class="button is-primary pull-right" href="/job-opportunity">{{ _("Post a Job") }}</a>
+
+  {% if allow_posting and jobs | length %}
+  <a class="button is-primary pull-right" href="/job-opportunity?new=1">{{ _("Post a Job") }}</a>
+  {% endif %}
+
   <div class="course-home-headings">{{ _("Job Openings") }}</div>
-    <div class="cards-parent">
+  {% if jobs | length %}
+  <div class="job-card-parent">
       {% for job in jobs %}
         <div class="common-card-style course-card">
           <div class="job-card">
-            <div>
-              <div class="course-tags">
-                <div class="course-card-pills">{{ _(job.type) }}</div>
-                <div class="course-card-pills">{{ job.location }}</div>
-              </div>
-              <div class="job-card-info">
-                <div class="bold-title">{{ _(job.job_title) }}</div>
-                <small>{{ job.company_name }}</small>
-              </div>
-            </div>
             <div class="avatar avatar-large" title="{{ job.company_name}}">
               <span class="avatar-frame company-logo" style="background-image: url( {{ job.company_logo | urlencode }} );"></span>
             </div>
+            <div class="job-card-info">
+              <div class="d-flex mb-1">
+                <div class="course-card-pills">{{ _(job.type) }}</div>
+                <div class="course-card-pills">{{ job.location }}</div>
+              </div>
+              <div class="card-heading">{{ _(job.job_title) }}</div>
+              <div>{{ job.company_name }}</div>
+            </div>
+            <div class="small">Posted on: {{ frappe.utils.format_date(job.creation, "medium") }}</div>
           </div>
           <a class="stretched-link" href="/jobs/{{ job.name }}"></a>
         </div>
       {% endfor %}
     </div>
+    {% else %}
+    <div class="empty-state text-center">
+      <img class="icon icon-xl" src="/assets/frappe/icons/timeless/message.svg">
+      <div class="course-home-headings mt-4 mb-0" style="color: inherit;"> {{ _("No open positions") }} </div>
+      <div class="small mb-6"> {{ _("There are no job openings available.") }} </div>
+      {% if allow_posting %}
+      <a class="button is-secondary dark-links m-auto" href="/job-opportunity?new=1">{{ _("Post a Job") }}</a>
+      {% endif %}
+    </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/school/www/jobs/index.py
+++ b/school/www/jobs/index.py
@@ -8,7 +8,7 @@ def get_context(context):
         },
         [
             "job_title", "location", "type", "company_name",
-            "company_logo", "name"
+            "company_logo", "name", "creation"
         ],
         order_by="creation desc")
 

--- a/school/www/jobs/index.py
+++ b/school/www/jobs/index.py
@@ -3,8 +3,8 @@ import frappe
 def get_context(context):
     context.jobs = frappe.get_all("Job Opportunity",
         {
-            "status": "Approved",
-            "job_opportunity_status": "Open"
+            "status": "Open",
+            "disabled": False
         },
         [
             "job_title", "location", "type", "company_name",

--- a/school/www/jobs/job.html
+++ b/school/www/jobs/job.html
@@ -8,23 +8,28 @@
   <div class="container">
     {{ BreadCrumb(job) }}
     <div class="common-card-style thread-card">
-      <div  class="job-card">
-        <div>
-          <span class="course-tags">
-            <div class="course-card-pills">{{ _(job.type) }}</div>
-            <div class="course-card-pills">{{ job.location }}</div>
-          </span>
-          <div class="job-card-info">
-            <div class="card-heading">{{ _(job.job_title) }}</div>
-            <a class="dark-links" href="{{ job.company_website }}">{{ job.company_name }}</a>
-            <div class="small mt-1">Posted On: {{ frappe.utils.format_date(job.creation, "medium") }}</div>
-          </div>
-        </div>
+      <div class="d-flex">
         <div class="avatar avatar-large" title="{{ job.company_name}}">
           <span class="avatar-frame company-logo" style="background-image: url( {{ job.company_logo | urlencode }} );"></span>
         </div>
+        <div class="job-card-info">
+          <span class="d-flex mb-1">
+            <div class="course-card-pills">{{ _(job.type) }}</div>
+            <div class="course-card-pills">{{ job.location }}</div>
+          </span>
+          <div class="">
+            <div class="card-heading">{{ _(job.job_title) }}</div>
+            <a class="dark-links" href="{{ job.company_website }}">{{ job.company_name }}</a>
+          </div>
+        </div>
+        <div>
+          <div class="small">Posted On: {{ frappe.utils.format_date(job.creation, "medium") }}</div>
+          <a class="pull-right mt-3" href="/job-opportunity/{{ job.name }}">Edit</a>
+        </div>
+
       </div>
-      <div class="job-description-section">
+
+      <div class="mt-5">
         <div>{{ _(job.description) }}</div>
         <a class="button is-primary mt-5" href="{{ job.application_link }}">{{ _("Apply Now") }}</a>
       </div>

--- a/school/www/jobs/job.html
+++ b/school/www/jobs/job.html
@@ -1,5 +1,4 @@
 {% extends "templates/base.html" %}
-{% from "www/hackathons/macros/card.html" import null_card %}
 {% block title %}{{ _(job.job_title) }}{% endblock %}
 
 {% block content %}
@@ -7,31 +6,50 @@
 <div class="common-page-style">
   <div class="container">
     {{ BreadCrumb(job) }}
-    <div class="common-card-style thread-card">
-      <div class="d-flex">
-        <div class="avatar avatar-large" title="{{ job.company_name}}">
-          <span class="avatar-frame company-logo" style="background-image: url( {{ job.company_logo | urlencode }} );"></span>
-        </div>
-        <div class="job-card-info">
-          <span class="d-flex mb-1">
-            <div class="course-card-pills">{{ _(job.type) }}</div>
-            <div class="course-card-pills">{{ job.location }}</div>
-          </span>
-          <div class="">
-            <div class="card-heading">{{ _(job.job_title) }}</div>
-            <a class="dark-links" href="{{ job.company_website }}">{{ job.company_name }}</a>
-          </div>
-        </div>
-        <div>
-          <div class="small">Posted On: {{ frappe.utils.format_date(job.creation, "medium") }}</div>
-          <a class="pull-right mt-3" href="/job-opportunity/{{ job.name }}">Edit</a>
-        </div>
-
-      </div>
-
-      <div class="mt-5">
+    <div class="common-card-style job-detail-card">
+      {% set show_edit_link = True %}
+      {% include "school/templates/job_card.html" %}
+      <div class="p-4">
         <div>{{ _(job.description) }}</div>
-        <a class="button is-primary mt-5" href="{{ job.application_link }}">{{ _("Apply Now") }}</a>
+        <div class="d-flex justify-content-between mt-5">
+          <a class="button is-primary" href="{{ job.application_link }}">{{ _("Apply Now") }}</a>
+          <div class="button is-secondary" id="report">{{ _("Report this post") }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade report-modal" id="report-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel"
+  aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div class="font-weight-bold">{{ _("Report this Post") }}</div>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <form class="review-form" id="review-form">
+          <div class="form-group">
+            <div class="clearfix">
+              <label class="control-label reqd" style="padding-right: 0px;">{{ _("Reason for reporting") }}</label>
+            </div>
+            <div class="control-input-wrapper">
+              <div class="control-input">
+                <textarea type="text" autocomplete="off" class="input-with-feedback form-control report-field"
+                  data-fieldtype="Text" data-fieldname="feedback_comments" placeholder="" style="height: 200px;"
+                  spellcheck="false"></textarea>
+              </div>
+            </div>
+          </div>
+          <p class="error-field muted-text"></p>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <div class="button submit-review is-primary" data-job="{{ job.name }}" id="submit-report">
+          Report</div>
       </div>
     </div>
   </div>

--- a/school/www/jobs/job.html
+++ b/school/www/jobs/job.html
@@ -11,14 +11,14 @@
       {% include "school/templates/job_card.html" %}
       <div class="p-4">
         <div>{{ _(job.description) }}</div>
-        {% if frappe.session.user != "Guest" %}
         <div class="d-flex justify-content-between mt-5">
+          {% if frappe.session.user != "Guest" %}
           <a class="button is-primary" href="{{ job.application_link }}">{{ _("Apply Now") }}</a>
           <div class="button is-secondary" id="report">{{ _("Report this post") }}</div>
+          {% else %}
+          <a class="button is-secondary dark-links" href="/login?redirect-to=/jobs/{{ job.name }}">Login to apply for this job.</a>
+          {% endif %}
         </div>
-        {% else %}
-        <p class="small alert alert-secondary text-center">Login to apply for this job.</p>
-        {% endif %}
       </div>
     </div>
   </div>

--- a/school/www/jobs/job.html
+++ b/school/www/jobs/job.html
@@ -11,10 +11,14 @@
       {% include "school/templates/job_card.html" %}
       <div class="p-4">
         <div>{{ _(job.description) }}</div>
+        {% if frappe.session.user != "Guest" %}
         <div class="d-flex justify-content-between mt-5">
           <a class="button is-primary" href="{{ job.application_link }}">{{ _("Apply Now") }}</a>
           <div class="button is-secondary" id="report">{{ _("Report this post") }}</div>
         </div>
+        {% else %}
+        <p class="small alert alert-secondary text-center">Login to apply for this job.</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/school/www/jobs/job.js
+++ b/school/www/jobs/job.js
@@ -21,7 +21,8 @@ const report = (e) => {
       "reason": $(".report-field").val()
     },
     callback: (data) => {
-      frappe.msgprint(__("Thanks for informing us about this post. Site admins will look into this and take an appropriate action soon."))
+      $(".report-modal").modal("hide");
+      frappe.msgprint(__("Thanks for informing us about this post. The Admins will look into this and take an appropriate action soon."))
     }
   })
 }

--- a/school/www/jobs/job.js
+++ b/school/www/jobs/job.js
@@ -1,0 +1,27 @@
+frappe.ready(() => {
+  $("#report").click((e) => {
+    open_report_dialog(e);
+  });
+
+  $("#submit-report").click((e) => {
+    report(e);
+  });
+});
+
+const open_report_dialog = (e) => {
+  e.preventDefault();
+  $("#report-modal").modal("show");
+};
+
+const report = (e) => {
+  frappe.call({
+    method: "school.job.doctype.job_opportunity.job_opportunity.report",
+    args: {
+      "job": $(e.currentTarget).data("job"),
+      "reason": $(".report-field").val()
+    },
+    callback: (data) => {
+      frappe.msgprint(__("Thanks for informing us about this post. Site admins will look into this and take an appropriate action soon."))
+    }
+  })
+}

--- a/school/www/jobs/job.js
+++ b/school/www/jobs/job.js
@@ -22,7 +22,7 @@ const report = (e) => {
     },
     callback: (data) => {
       $(".report-modal").modal("hide");
-      frappe.msgprint(__("Thanks for informing us about this post. The Admins will look into this and take an appropriate action soon."))
+      frappe.msgprint(__("Thanks for informing us about this post. The admin will look into it and take an appropriate action soon."))
     }
   })
 }


### PR DESCRIPTION
1. Admins can now select if users should post jobs from the website.

<img width="1213" alt="Screenshot 2022-01-11 at 7 44 02 PM" src="https://user-images.githubusercontent.com/31363128/148960029-9f08f21f-95d8-4678-9638-d46ae8673c4e.png">

2. Job Opportunities can now be disabled.

<img width="969" alt="Screenshot 2022-01-11 at 7 50 55 PM" src="https://user-images.githubusercontent.com/31363128/148960049-621543e5-d168-4018-82d9-772f0b501365.png">

3. No approval would be needed for Job opportunities from now. Instead, if users find a particular posting as suspicious, they can report such posts.

https://user-images.githubusercontent.com/31363128/148960266-185ce3b8-9d8c-412a-b7ba-31c1eaea5043.mov
