### PR TITLE
feat: pass context to page extensions

### DIFF
--- a/school/plugins.py
+++ b/school/plugins.py
@@ -24,6 +24,11 @@ class PageExtension:
     `render_footer()` methods to inject whatever styles/scripts into
     the webpage.
     """
+    def __init__(self):
+        self.context = frappe._dict()
+
+    def set_context(self, context):
+        self.context = context
 
     def render_header(self):
         """Returns the HTML snippet to be included in the head section

--- a/school/www/batch/learn.py
+++ b/school/www/batch/learn.py
@@ -31,7 +31,7 @@ def get_context(context):
         "description": meta_info
     }
 
-    context.page_extensions = get_page_extensions()
+    context.page_extensions = get_page_extensions(context)
     context.page_context = {
         "course": context.course.name,
         "batch": context.get("batch") and context.batch.name,
@@ -52,8 +52,10 @@ def get_lesson_index(course, batch, user):
     lesson = batch.get_current_lesson(user)
     return lesson and course.get_lesson_index(lesson)
 
-def get_page_extensions():
+def get_page_extensions(context):
     default_value = ["school.plugins.PageExtension"]
     classnames = frappe.get_hooks("school_lesson_page_extensions") or default_value
     extensions = [frappe.get_attr(name)() for name in classnames]
+    for e in extensions:
+        e.set_context(context)
     return extensions


### PR DESCRIPTION
Pass the context to page extensions to allow them to make decisions
based on the context. For example, an extension to load the course
specific scripts. This is currently not possible because the course
details are not availale to the page extensions. Made this possible by
passing the context to page extensions.